### PR TITLE
Add 'functional' include needed by Litecore

### DIFF
--- a/include/sockpp/mbedtls_context.h
+++ b/include/sockpp/mbedtls_context.h
@@ -51,6 +51,7 @@
 #include "sockpp/tls_socket.h"
 #include <memory>
 #include <string>
+#include <functional>
 
 struct mbedtls_pk_context;
 struct mbedtls_ssl_config;


### PR DESCRIPTION
This fix allows Couchbase-Lite-C to compile with CMake on Windows.

It consists only of including "functional" in mbedtls_context.h