### PR TITLE
Ignore positive integer errors from mbedtls_x509_crt_parse

### DIFF
--- a/include/sockpp/mbedtls_context.h
+++ b/include/sockpp/mbedtls_context.h
@@ -100,7 +100,7 @@ namespace sockpp {
         struct key;
 
         int verify_callback(mbedtls_x509_crt *crt, int depth, uint32_t *flags);
-        static std::unique_ptr<cert> parse_cert(const std::string &cert_data);
+        static std::unique_ptr<cert> parse_cert(const std::string &cert_data, bool partialOk);
 
         std::unique_ptr<mbedtls_ssl_config> ssl_config_;
         std::unique_ptr<cert> root_certs_;

--- a/src/mbedtls_context.cpp
+++ b/src/mbedtls_context.cpp
@@ -449,7 +449,11 @@ namespace sockpp {
         if (ret != 0) {
 	        if(ret < 0 || !partialOk) {
 		        log_mbed_ret(ret, "mbedtls_x509_crt_parse");
-				throw sys_error(ret);   //FIXME: Not an errno; use different exception?
+	        	if(ret > 0) {
+	        		ret = MBEDTLS_ERR_X509_CERT_VERIFY_FAILED;
+	        	}
+	        	
+				throw sys_error(ret);
 	        }
         }
         return c;


### PR DESCRIPTION
Only in cases of importing system certs.  Some of them may be so old (or maybe so new?) as to be unable to be read by mbedTLS.  The behavior should not be to discard everything.  However when specifying our own chains we want everything to be valid.