### PR TITLE
Add Windows code to convert TLS certificates to PEM

### DIFF
--- a/src/mbedtls_context.cpp
+++ b/src/mbedtls_context.cpp
@@ -659,6 +659,7 @@ namespace sockpp {
                 return "";
             }
             certs.write(pCertPEM, pCertPEMSize);
+            free(pCertPEM);
         }
 
         CertCloseStore(hStore, CERT_CLOSE_STORE_FORCE_FLAG);

--- a/src/mbedtls_context.cpp
+++ b/src/mbedtls_context.cpp
@@ -452,7 +452,7 @@ namespace sockpp {
 	        	if(ret > 0) {
 	        		ret = MBEDTLS_ERR_X509_CERT_VERIFY_FAILED;
 	        	}
-	        	
+
 				throw sys_error(ret);
 	        }
         }
@@ -642,19 +642,27 @@ namespace sockpp {
 #elif defined(_WIN32)
     // Windows:
     static string read_system_root_certs() {
-	    PCCERT_CONTEXT pContext = nullptr;
-	    HCERTSTORE hStore = CertOpenSystemStore(NULL, "ROOT");
-		if(hStore == nullptr) {
-			return "";
-		}
+        PCCERT_CONTEXT pContext = nullptr;
+        HCERTSTORE hStore = CertOpenSystemStore(NULL, "ROOT");
+        if(hStore == nullptr) {
+            return "";
+        }
 
-		stringstream certs;
-		while ((pContext = CertEnumCertificatesInStore(hStore, pContext))) {
-			certs.write((const char*)pContext->pbCertEncoded, pContext->cbCertEncoded);
-		}
+        stringstream certs;
+        while ((pContext = CertEnumCertificatesInStore(hStore, pContext))) {
+            DWORD pCertPEMSize = 0;
+            if (!CryptBinaryToStringA(pContext->pbCertEncoded, pContext->cbCertEncoded, CRYPT_STRING_BASE64HEADER, NULL, &pCertPEMSize)) {
+                return "";
+            }
+            LPSTR pCertPEM = (LPSTR)malloc(pCertPEMSize);
+            if (!CryptBinaryToStringA(pContext->pbCertEncoded, pContext->cbCertEncoded, CRYPT_STRING_BASE64HEADER, pCertPEM, &pCertPEMSize)) {
+                return "";
+            }
+            certs.write(pCertPEM, pCertPEMSize);
+        }
 
-		CertCloseStore(hStore, CERT_CLOSE_STORE_FORCE_FLAG);
-		return certs.str();
+        CertCloseStore(hStore, CERT_CLOSE_STORE_FORCE_FLAG);
+        return certs.str();
     }
 
 #else


### PR DESCRIPTION
This PR adds code to convert each trusted root certificate found to PEM format before concatenating it to the stringstream of certificates. This changes only Windows code.

This issue was causing the error

`[WS] ERROR: mbedTLS©: x509_verify_cert() returned -9984 (-0x2700)
TLS: mbedtls error -0x2700 from mbedtls_ssl_handshake: X509 - Certificate verification failed, e.g. CRL, CA or signature check failed`

reported in [this forum thread.](https://forums.couchbase.com/t/litec-issue-on-windows-non-blocking-socket-operation-error/24770/4)

Please let me know if I can clarify anything, thanks.
Victor Berger
ON Semiconductor