### PR TITLE
Brush up a couple of logical points regarding validation

### DIFF
--- a/include/sockpp/mbedtls_context.h
+++ b/include/sockpp/mbedtls_context.h
@@ -105,6 +105,8 @@ namespace sockpp {
 
         using Logger = std::function<void(int level, const char *filename, int line, const char *message)>;
         void set_logger(int threshold, Logger);
+        
+        std::string get_peer_certificate() const;
 
         /**
          * TLS "fatal alert" codes are mapped into error codes returned from the socket's last_error().
@@ -126,6 +128,7 @@ namespace sockpp {
         RootCertLocator root_cert_locator_;
         std::unique_ptr<cert> root_certs_;
         std::unique_ptr<cert> pinned_cert_;
+        std::unique_ptr<cert> received_cert_;
 
         std::unique_ptr<cert> identity_cert_;
         std::unique_ptr<key> identity_key_;

--- a/include/sockpp/mbedtls_context.h
+++ b/include/sockpp/mbedtls_context.h
@@ -106,7 +106,7 @@ namespace sockpp {
         using Logger = std::function<void(int level, const char *filename, int line, const char *message)>;
         void set_logger(int threshold, Logger);
         
-        std::string get_peer_certificate() const;
+        const std::string& get_peer_certificate() const { return received_cert_data_; }
 
         /**
          * TLS "fatal alert" codes are mapped into error codes returned from the socket's last_error().
@@ -128,7 +128,7 @@ namespace sockpp {
         RootCertLocator root_cert_locator_;
         std::unique_ptr<cert> root_certs_;
         std::unique_ptr<cert> pinned_cert_;
-        std::unique_ptr<cert> received_cert_;
+        std::string received_cert_data_;
 
         std::unique_ptr<cert> identity_cert_;
         std::unique_ptr<key> identity_key_;

--- a/src/mbedtls_context.cpp
+++ b/src/mbedtls_context.cpp
@@ -639,11 +639,7 @@ namespace sockpp {
         }
 
         int status = -1;
-        
-        // Is there a better way to do this then parsing everything again?
-        received_cert_.reset(new cert);
-        mbedtls_x509_crt_parse(received_cert_.get(), crt->raw.p, crt->raw.len);
-        
+        received_cert_data_ = string((const char *)crt->raw.p, crt->raw.len);
         
         if (pinned_cert_) {
             status = (crt->raw.len == pinned_cert_->raw.len
@@ -700,14 +696,6 @@ namespace sockpp {
     {
         assert(socketRole == role());
         return make_unique<mbedtls_socket>(move(socket), *this, peer_name);
-    }
-
-    string mbedtls_context::get_peer_certificate() const {
-        if(!received_cert_) {
-            return "";
-        }
-        
-        return string((const char *)received_cert_->raw.p, received_cert_->raw.len);
     }
 
 

--- a/src/mbedtls_context.cpp
+++ b/src/mbedtls_context.cpp
@@ -237,8 +237,12 @@ namespace sockpp {
 
         string peer_certificate() override {
             auto cert = mbedtls_ssl_get_peer_cert(&ssl_);
-            if (!cert)
-                return "";
+            if (!cert) {
+                // This should only happen in a failed handshake scenario, or if there
+                // was no cert to begin with
+                return context_.get_peer_certificate();
+            }
+            
             return string((const char*)cert->raw.p, cert->raw.len);
         }
 
@@ -635,6 +639,12 @@ namespace sockpp {
         }
 
         int status = -1;
+        
+        // Is there a better way to do this then parsing everything again?
+        received_cert_.reset(new cert);
+        mbedtls_x509_crt_parse(received_cert_.get(), crt->raw.p, crt->raw.len);
+        
+        
         if (pinned_cert_) {
             status = (crt->raw.len == pinned_cert_->raw.len
                       && 0 == memcmp(crt->raw.p, pinned_cert_->raw.p, crt->raw.len));
@@ -690,6 +700,14 @@ namespace sockpp {
     {
         assert(socketRole == role());
         return make_unique<mbedtls_socket>(move(socket), *this, peer_name);
+    }
+
+    string mbedtls_context::get_peer_certificate() const {
+        if(!received_cert_) {
+            return "";
+        }
+        
+        return string((const char *)received_cert_->raw.p, received_cert_->raw.len);
     }
 
 


### PR DESCRIPTION
1. There is no way to reset the state of the validation back to using the system certificates, so take setting a null root cert locator callback to mean that
2. When using a pinned cert, all errors up the chain should be ignored because all we care about are the potential errors on the leaf