### PR TITLE
Add the option to control sending client cert CA list

### DIFF
--- a/include/sockpp/mbedtls_context.h
+++ b/include/sockpp/mbedtls_context.h
@@ -81,7 +81,7 @@ namespace sockpp {
         void set_root_cert_locator(RootCertLocator loc);
         RootCertLocator root_cert_locator() const           {return root_cert_locator_;}
 
-        void require_peer_cert(role_t, bool) override;
+        void require_peer_cert(role_t, bool, bool) override;
         void allow_only_certificate(const std::string &certData) override;
 
         void allow_only_certificate(mbedtls_x509_crt *certificate);

--- a/include/sockpp/tls_context.h
+++ b/include/sockpp/tls_context.h
@@ -107,8 +107,10 @@ namespace sockpp {
          *   client certificate authentication.
          * @param role  The role you are configuring this setting for
          * @param require Pass true to require a valid peer certificate, false to not require.
+         * @param sendCAList Pass true to automatically generate a list of trusted CAs for
+         *                   the received client cert, if possible (only applies when role == SERVER)
          */
-        virtual void require_peer_cert(role_t role, bool require) =0;
+        virtual void require_peer_cert(role_t role, bool require, bool sendCAList) =0;
 
         /**
          * Requires that the peer have the exact certificate given.

--- a/src/mbedtls_context.cpp
+++ b/src/mbedtls_context.cpp
@@ -601,11 +601,17 @@ namespace sockpp {
     }
 
 
-    void mbedtls_context::require_peer_cert(role_t forRole, bool require) {
+    void mbedtls_context::require_peer_cert(role_t forRole, bool require, bool sendCAList) {
         if (forRole != role())
             return;
         int authMode = (require ? MBEDTLS_SSL_VERIFY_REQUIRED : MBEDTLS_SSL_VERIFY_OPTIONAL);
         mbedtls_ssl_conf_authmode(ssl_config_.get(), authMode);
+
+    	if(role() == SERVER) {
+    		mbedtls_ssl_conf_cert_req_ca_list(ssl_config_.get(), sendCAList
+				? MBEDTLS_SSL_CERT_REQ_CA_LIST_ENABLED
+				: MBEDTLS_SSL_CERT_REQ_CA_LIST_DISABLED);
+		}
     }
 
 


### PR DESCRIPTION
This is an optional part of the TLS handshake in which a list of acceptable CAs are sent to the client along with the certificate request.  A well behaved client will check this and not send any certs that are not issued by these CAs.  This doesn't jive well with some late stage authentication methods that don't make use of CA certs, so provide an option to disable it (it is enabled by default).