### PR TITLE
CBL-1438: Fix handling of WSAEWOULDBLOCK

### DIFF
--- a/src/mbedtls_context.cpp
+++ b/src/mbedtls_context.cpp
@@ -377,16 +377,28 @@ namespace sockpp {
             switch (result.error) {
                 case EPIPE:
                 case ECONNRESET:
+#ifdef _WIN32
+                case WSAECONNRESET:
+#endif
                     return MBEDTLS_ERR_NET_CONN_RESET;
                 case EINTR:
                 case EWOULDBLOCK:
 #if defined(EAGAIN) && EAGAIN != EWOULDBLOCK    // these are usually synonyms
                 case EAGAIN:
 #endif
+#ifdef _WIN32
+                case WSAEINTR:
+                case WSAEWOULDBLOCK:
+#endif
                     log(">>> BIO returning MBEDTLS_ERR_SSL_WANT_%s", reading ?"READ":"WRITE");
                     return reading ? MBEDTLS_ERR_SSL_WANT_READ
                                    : MBEDTLS_ERR_SSL_WANT_WRITE;
                 default:
+#ifdef _WIN32
+                    log(">>> BIO WSA error code %d results in a transfer error", result.error);
+#else
+                    log(">>> BIO Error code %d results in a transfer error", result.error);
+#endif
                     return reading ? MBEDTLS_ERR_NET_RECV_FAILED
                                    : MBEDTLS_ERR_NET_SEND_FAILED;
             }


### PR DESCRIPTION
WSAEWOULDBLOCK should be handled the same as EWOULDBLOCK - the connection should be retried according to [Microsoft documentation](https://docs.microsoft.com/en-us/windows/win32/winsock/windows-sockets-error-codes-2).