### PR TITLE
CBL-2976 : Verify pinned cert with any certs in the chain

### DIFF
--- a/include/sockpp/mbedtls_context.h
+++ b/include/sockpp/mbedtls_context.h
@@ -128,7 +128,7 @@ namespace sockpp {
         RootCertLocator root_cert_locator_;
         std::unique_ptr<cert> root_certs_;
         std::unique_ptr<cert> pinned_cert_;
-        int pinned_cert_validation_result_;
+        bool pinned_cert_validation_result_;
         std::string received_cert_data_;
 
         std::unique_ptr<cert> identity_cert_;

--- a/include/sockpp/mbedtls_context.h
+++ b/include/sockpp/mbedtls_context.h
@@ -128,7 +128,7 @@ namespace sockpp {
         RootCertLocator root_cert_locator_;
         std::unique_ptr<cert> root_certs_;
         std::unique_ptr<cert> pinned_cert_;
-        bool pinned_cert_validation_result_;
+        bool pinned_cert_validation_result_ {false};
         std::string received_cert_data_;
 
         std::unique_ptr<cert> identity_cert_;

--- a/include/sockpp/mbedtls_context.h
+++ b/include/sockpp/mbedtls_context.h
@@ -128,6 +128,7 @@ namespace sockpp {
         RootCertLocator root_cert_locator_;
         std::unique_ptr<cert> root_certs_;
         std::unique_ptr<cert> pinned_cert_;
+        int pinned_cert_validation_result_;
         std::string received_cert_data_;
 
         std::unique_ptr<cert> identity_cert_;

--- a/src/mbedtls_context.cpp
+++ b/src/mbedtls_context.cpp
@@ -548,8 +548,7 @@ namespace sockpp {
 
 
     mbedtls_context::mbedtls_context(role_t r)
-    :ssl_config_(new mbedtls_ssl_config),
-     pinned_cert_validation_result_(false)
+    :ssl_config_(new mbedtls_ssl_config)
     {
         mbedtls_ssl_config_init(ssl_config_.get());
         mbedtls_ssl_conf_rng(ssl_config_.get(), mbedtls_ctr_drbg_random, get_drbg_context());

--- a/src/mbedtls_context.cpp
+++ b/src/mbedtls_context.cpp
@@ -548,7 +548,8 @@ namespace sockpp {
 
 
     mbedtls_context::mbedtls_context(role_t r)
-    :ssl_config_(new mbedtls_ssl_config)
+    :ssl_config_(new mbedtls_ssl_config),
+     pinned_cert_validation_result_(0)
     {
         mbedtls_ssl_config_init(ssl_config_.get());
         mbedtls_ssl_conf_rng(ssl_config_.get(), mbedtls_ctr_drbg_random, get_drbg_context());
@@ -673,32 +674,46 @@ namespace sockpp {
     }
 
 
-    // callback from mbedTLS cert validation (see above)
+    // Callback from mbedTLS cert validation (see above)
+    //
+    // When a pinned cert is specified, the verify_callback will compare the pinned cert with
+    // each cert in the chain. If one of the certs in the chain matches with the pinned cert,
+    // the server servers are trusted.
+    //
+    // The verify_callback is called for each cert in the chain from root to leaf cert. The
+    // pinned_cert_validation_result_ will store the previous comparison result. If the
+    // comparison result is already matched, the comparison will be skipped.
+    //
+    // The last callback for the leaf cert is where the comparison or verification is set
+    // to the status flags. The flags of the parent certs are ignored (clear).
+    //
     int mbedtls_context::verify_callback(mbedtls_x509_crt *crt, int depth, uint32_t *flags) {
-        if (depth != 0) {
-            if(pinned_cert_) {
-                // We only care that the end cert matches, clear all other errors
-                *flags = 0;
+        if (pinned_cert_ && pinned_cert_validation_result_ == 0) {
+            pinned_cert_validation_result_ = (crt->raw.len == pinned_cert_->raw.len &&
+                                              0 == memcmp(crt->raw.p, pinned_cert_->raw.p, crt->raw.len));
+        }
+        
+        if (depth == 0) { // leaf cert
+            received_cert_data_ = string((const char *)crt->raw.p, crt->raw.len);
+            
+            int status = -1;
+            if (pinned_cert_) {
+                status = pinned_cert_validation_result_;
+            } else if (auto &callback = get_auth_callback(); callback) {
+                string certData((const char*)crt->raw.p, crt->raw.len);
+                status = callback(certData);
             }
             
-            return 0;
-        }
-
-        int status = -1;
-        received_cert_data_ = string((const char *)crt->raw.p, crt->raw.len);
-        
-        if (pinned_cert_) {
-            status = (crt->raw.len == pinned_cert_->raw.len
-                      && 0 == memcmp(crt->raw.p, pinned_cert_->raw.p, crt->raw.len));
-        } else if (auto &callback = get_auth_callback(); callback) {
-            string certData((const char*)crt->raw.p, crt->raw.len);
-            status = callback(certData);
-        }
-        
-        if (status > 0) {
-            *flags &= ~(MBEDTLS_X509_BADCERT_NOT_TRUSTED | MBEDTLS_X509_BADCERT_CN_MISMATCH);
-        } else if (status == 0) {
-            *flags |= MBEDTLS_X509_BADCERT_OTHER;
+            if (status > 0) {
+                *flags &= ~(MBEDTLS_X509_BADCERT_NOT_TRUSTED | MBEDTLS_X509_BADCERT_CN_MISMATCH);
+            } else if (status == 0) {
+                *flags |= MBEDTLS_X509_BADCERT_OTHER;
+            }
+        } else {
+            if (pinned_cert_) {
+                // We only care the result when last callback is called, clear all other errors
+                *flags = 0;
+            }
         }
         return 0;
     }

--- a/src/mbedtls_context.cpp
+++ b/src/mbedtls_context.cpp
@@ -549,7 +549,7 @@ namespace sockpp {
 
     mbedtls_context::mbedtls_context(role_t r)
     :ssl_config_(new mbedtls_ssl_config),
-     pinned_cert_validation_result_(0)
+     pinned_cert_validation_result_(false)
     {
         mbedtls_ssl_config_init(ssl_config_.get());
         mbedtls_ssl_conf_rng(ssl_config_.get(), mbedtls_ctr_drbg_random, get_drbg_context());
@@ -677,8 +677,8 @@ namespace sockpp {
     // Callback from mbedTLS cert validation (see above)
     //
     // When a pinned cert is specified, the verify_callback will compare the pinned cert with
-    // each cert in the chain. If one of the certs in the chain matches with the pinned cert,
-    // the server servers are trusted.
+    // each cert in the chain. If the pinned cert matches one of the certs in the chain, the
+    // presented cert (leaf cert) is trusted.
     //
     // The verify_callback is called for each cert in the chain from root to leaf cert. The
     // pinned_cert_validation_result_ will store the previous comparison result. If the
@@ -688,7 +688,7 @@ namespace sockpp {
     // to the status flags. The flags of the parent certs are ignored (clear).
     //
     int mbedtls_context::verify_callback(mbedtls_x509_crt *crt, int depth, uint32_t *flags) {
-        if (pinned_cert_ && pinned_cert_validation_result_ == 0) {
+        if (pinned_cert_ && !pinned_cert_validation_result_) {
             pinned_cert_validation_result_ = (crt->raw.len == pinned_cert_->raw.len &&
                                               0 == memcmp(crt->raw.p, pinned_cert_->raw.p, crt->raw.len));
         }


### PR DESCRIPTION
Updated mbedtls_context::verify_callback to compare the pinned cert with any certs in the chain. If the pinned cert matches one of the certs in the chain, the verification is successful.

Note: There will be a PR submitted to LiteCore, which contains tests for the pinned cert feature.