### PR TITLE
CBL-2969 : Make Connector support Network Interface

### DIFF
--- a/include/sockpp/connector.h
+++ b/include/sockpp/connector.h
@@ -49,10 +49,32 @@
 
 #include "sockpp/stream_socket.h"
 #include "sockpp/sock_address.h"
+#include <optional>
 
 namespace sockpp {
 
 /////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Class for storing network interface information.
+ */
+class Interface
+{
+    std::string _name;
+    uint8_t _family;
+    in_addr _addr4;
+    in6_addr _addr6;
+    
+public:
+    
+    Interface(std::string name, in_addr addr4)   : _name(name), _addr4(addr4) {_family = AF_INET;}
+    Interface(std::string name, in6_addr addr6)  : _name(name), _addr6(addr6) {_family = AF_INET6;}
+    
+    const std::string& name() const             {return _name;}
+    uint8_t family() const                      {return _family;}
+    const in_addr& addr4() const                {return _addr4;}
+    const in6_addr& addr6() const               {return _addr6;}
+};
 
 /**
  * Class to create a client stream connection.
@@ -79,17 +101,27 @@ public:
 	/**
 	 * Creates the connector and attempts to connect to the specified
 	 * address.
-	 * @param addr The remote server address. 
+	 * @param addr The remote server address.
+     * @param inf The interface used for connecting to the server. If not specified, an interface based on the routing table will be used.
+     * @throw EAFNOSUPPORT error if the specified interface's address family doesn't match with the server's address family
 	 */
-	connector(const sock_address& addr) { connect(addr); }
+	connector(const sock_address& addr, std::optional<Interface> inf=std::nullopt) {
+        connect(addr, inf);
+    }
 	/**
 	 * Creates the connector and attempts to connect to the specified
 	 * address, with a timeout.
      * If the operation times out, the \ref last_error will be set to ETIMEOUT.
 	 * @param addr The remote server address.
      * @param t The duration after which to give up. Zero means never.
+     * @param inf The interface used for connecting to the server. If not specified, an interface based on the routing table will be used.
+     * @throw EAFNOSUPPORT error if the specified interface's address family doesn't match with the server's address family
 	 */
-	connector(const sock_address& addr, std::chrono::milliseconds t) { connect(addr, t); }
+	connector(const sock_address& addr,
+              std::chrono::milliseconds t,
+              std::optional<Interface> inf=std::nullopt) {
+        connect(addr, t, inf);
+    }
 	/**
 	 * Move constructor.
 	 * Creates a connector by moving the other connector to this one.
@@ -119,9 +151,11 @@ public:
      * If the socket is currently connected, this will close the current
      * connection and open the new one.
 	 * @param addr The remote server address.
+     * @param inf The interface used for connecting to the server. If not specified, an interface based on the routing table will be used.
 	 * @return @em true on success, @em false on error
+     * @throw EAFNOSUPPORT error if the specified interface's address family doesn't match with the server's address family
 	 */
-	bool connect(const sock_address& addr);
+	bool connect(const sock_address& addr, std::optional<Interface> inf=std::nullopt);
 	/**
      * Attempts to connect to the specified server, with a timeout.
      * If the socket is currently connected, this will close the current
@@ -129,9 +163,17 @@ public:
      * If the operation times out, the \ref last_error will be set to ETIMEOUT.
 	 * @param addr The remote server address.
      * @param timeout The duration after which to give up. Zero means never.
+     * @param inf The interface used for connecting to the server. If not specified, an interface based on the routing table will be used.
 	 * @return @em true on success, @em false on error
+     * @throw EAFNOSUPPORT error if the specified interface's address family doesn't match with the server's address family
 	 */
-	bool connect(const sock_address& addr, std::chrono::microseconds timeout);
+	bool connect(const sock_address& addr,
+                 std::chrono::microseconds timeout,
+                 std::optional<Interface> inf=std::nullopt);
+    
+private:
+    /** Set network interface option to the socket. */
+    bool set_network_interface(const Interface& inf);
 };
 
 /////////////////////////////////////////////////////////////////////////////

--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -35,9 +35,13 @@
 // --------------------------------------------------------------------------
 
 #include "sockpp/connector.h"
+#include "sockpp/exception.h"
 #include <cerrno>
 #ifndef WIN32
 #include <sys/poll.h>
+#endif
+#ifdef __APPLE__
+#include <net/if.h>
 #endif
 
 namespace sockpp {
@@ -71,10 +75,13 @@ bool connector::recreate(const sock_address& addr)
 
 /////////////////////////////////////////////////////////////////////////////
 
-bool connector::connect(const sock_address& addr)
+bool connector::connect(const sock_address& addr, std::optional<Interface> inf)
 {
 	if (!recreate(addr))
 		return false;
+    
+    if (inf && !set_network_interface(*inf))
+        return false;
 
 	if (!check_ret_bool(::connect(handle(), addr.sockaddr_ptr(), addr.size())))
 		return close_on_err();
@@ -84,12 +91,15 @@ bool connector::connect(const sock_address& addr)
 
 /////////////////////////////////////////////////////////////////////////////
 
-bool connector::connect(const sock_address& addr, std::chrono::microseconds timeout)
+bool connector::connect(const sock_address& addr, std::chrono::microseconds timeout, std::optional<Interface> inf)
 {
     if (timeout.count() <= 0)
-        return connect(addr);
+        return connect(addr, inf);
 
     if (!recreate(addr))
+        return false;
+    
+    if (inf && !set_network_interface(*inf))
         return false;
 
     set_non_blocking(true);
@@ -130,6 +140,39 @@ bool connector::connect(const sock_address& addr, std::chrono::microseconds time
 
     set_non_blocking(false);
 	return true;
+}
+
+bool connector::set_network_interface(const Interface& inf)
+{
+    auto addrFamily = family();
+    
+    // For AF_UNSPEC, assume IPv4:
+    if (addrFamily == AF_UNSPEC)
+        addrFamily = AF_INET;
+    
+    if ((addrFamily != AF_INET && addrFamily != AF_INET6) || addrFamily != inf.family())
+        throw sys_error(EAFNOSUPPORT);
+    
+#if defined(__APPLE__)
+    auto index = if_nametoindex(inf.name().c_str());
+    if (index == 0) {
+        set_last_error();
+        return false;
+    }
+    if (addrFamily == AF_INET)
+        return set_option(IPPROTO_IP, IP_BOUND_IF, &index, sizeof(index));
+    else
+        return set_option(IPPROTO_IPV6, IPV6_BOUND_IF, &index, sizeof(index));
+#elif defined(_WIN32)
+    if (addrFamily == AF_INET)
+        return set_option(IPPROTO_IP, IP_UNICAST_IF, &(inf.addr4()), sizeof(inf.addr4()));
+    else
+        return set_option(IPPROTO_IPV6, IPV6_UNICAST_IF, &(inf.addr6()), sizeof(inf.addr6()));
+#elif defined(__linux__)
+    return set_option(SOL_SOCKET, SO_BINDTODEVICE, inf.name().c_str(), inf.name().size());
+#else
+    throw sys_error(ENOTSUP);
+#endif
 }
 
 /////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
* Enhanced Connector class to allow to specify a Network Interface to connect to the remote server.

* Added Interface class for specifying a network interface.

* Allowed to specify a system error to the based Socket class extended by the Connector class.