### PR TITLE
CBL-3663: Fix LiteCore assertion failure

### DIFF
--- a/src/mbedtls_context.cpp
+++ b/src/mbedtls_context.cpp
@@ -338,7 +338,7 @@ namespace sockpp {
 
         // Translates mbedTLS error code to POSIX (errno)
         // Do not return 0 from this function, causes an assertion
-        //  failure in LiteCore TCPSocket::checkStreamError()
+        // failure in LiteCore TCPSocket::checkStreamError()
         int translate_mbed_err(int mbedErr) {
             switch (mbedErr) {
                 case MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY:

--- a/src/mbedtls_context.cpp
+++ b/src/mbedtls_context.cpp
@@ -337,10 +337,12 @@ namespace sockpp {
 
 
         // Translates mbedTLS error code to POSIX (errno)
+        // Do not return 0 from this function, causes an assertion
+        //  failure in LiteCore TCPSocket::checkStreamError()
         int translate_mbed_err(int mbedErr) {
             switch (mbedErr) {
                 case MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY:
-                    return 0;
+                    return ECONNRESET;
                 case MBEDTLS_ERR_SSL_WANT_READ:
                 case MBEDTLS_ERR_SSL_WANT_WRITE:
                     log(3, "mbedtls_socket returning EWOULDBLOCK");


### PR DESCRIPTION
Change return value of MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY to a valid POSIX error (ECONNRESET) rather than 0