### PR TITLE
CBL-4237 : Pass cert chain to the root_cert_locator()

### DIFF
--- a/src/mbedtls_context.cpp
+++ b/src/mbedtls_context.cpp
@@ -593,7 +593,7 @@ namespace sockpp {
         string certData;
         for (auto crt = child; crt; crt = crt->next) {
             size_t olen = 0;
-            unsigned char buf[4096];
+            unsigned char buf[10000];
             int ret = mbedtls_pem_write_buffer("-----BEGIN CERTIFICATE-----\n",
                                                "-----END CERTIFICATE-----\n",
                                                crt->raw.p, crt->raw.len,

--- a/src/mbedtls_context.cpp
+++ b/src/mbedtls_context.cpp
@@ -42,6 +42,7 @@
 #include <mbedtls/entropy.h>
 #include <mbedtls/error.h>
 #include <mbedtls/net_sockets.h>
+#include <mbedtls/pem.h>
 #include <mbedtls/ssl.h>
 #include <mutex>
 #include <chrono>
@@ -587,7 +588,30 @@ namespace sockpp {
     {
         if (!root_cert_locator_)
             return -1;
-        string certData((const char*)child->raw.p, child->raw.len);
+        
+        // Construct the cert chain including all intermediates in PEM format:
+        string certData;
+        for (auto crt = child; crt; crt = crt->next) {
+            size_t olen = 0;
+            unsigned char buf[4096];
+            int ret = mbedtls_pem_write_buffer("-----BEGIN CERTIFICATE-----\n",
+                                               "-----END CERTIFICATE-----\n",
+                                               crt->raw.p, crt->raw.len,
+                                               buf, sizeof(buf), &olen);
+            if (ret != 0) {
+                if (ret > 0) {
+                    ret = MBEDTLS_ERR_X509_CERT_UNKNOWN_FORMAT;
+                }
+                log_mbed_ret(ret, "mbedtls_pem_write_buffer");
+                return ret;
+            }
+            
+            if (olen > 0 && buf[olen-1] == '\0') {
+                olen = olen - 1; // Not include '\0'
+            }
+            certData.append((const char*)buf, olen);
+        }
+        
         string rootData;
         if (!root_cert_locator_(certData, rootData))
             return -1;//TEMP

--- a/src/mbedtls_context.cpp
+++ b/src/mbedtls_context.cpp
@@ -37,6 +37,7 @@
 #include "sockpp/mbedtls_context.h"
 #include "sockpp/connector.h"
 #include "sockpp/exception.h"
+#include <mbedtls/base64.h>
 #include <mbedtls/ctr_drbg.h>
 #include <mbedtls/debug.h>
 #include <mbedtls/entropy.h>
@@ -592,12 +593,20 @@ namespace sockpp {
         // Construct the cert chain including all intermediates in PEM format:
         string certData;
         for (auto crt = child; crt; crt = crt->next) {
-            size_t olen = 0;
-            unsigned char buf[10000];
-            int ret = mbedtls_pem_write_buffer("-----BEGIN CERTIFICATE-----\n",
+            int ret = 0;
+            size_t olen = 10000; // initial buffer size
+            std::vector<unsigned char> buf;
+            for (int i = 0; i < 2; i++) {
+                buf.resize(olen);
+                ret = mbedtls_pem_write_buffer("-----BEGIN CERTIFICATE-----\n",
                                                "-----END CERTIFICATE-----\n",
                                                crt->raw.p, crt->raw.len,
-                                               buf, sizeof(buf), &olen);
+                                               buf.data(), buf.size(), &olen);
+                if (ret != MBEDTLS_ERR_BASE64_BUFFER_TOO_SMALL) {
+                    break;
+                }
+            }
+            
             if (ret != 0) {
                 if (ret > 0) {
                     ret = MBEDTLS_ERR_X509_CERT_UNKNOWN_FORMAT;
@@ -609,7 +618,7 @@ namespace sockpp {
             if (olen > 0 && buf[olen-1] == '\0') {
                 olen = olen - 1; // Not include '\0'
             }
-            certData.append((const char*)buf, olen);
+            certData.append((const char*)buf.data(), olen);
         }
         
         string rootData;


### PR DESCRIPTION
**Background for CBL-4234:**

In LiteCore PublicKey+Apple.mm’s findSigningRootCert() for TLS CA cert validation, a SecTrust is created with only a leaf cert without its intermediate certs. As a result, when calling SecTrustEvaluateWithError() to evaluate the SecTrust (a technique to get all certs including the root CA cert used for verifying a CA signed cert), there is a warning error logged as follows:

```
[TLS] error: SecTrustEvaluateWithError failed: Error Domain=NSOSStatusErrorDomain Code=-25318 "errKCCreateChainFailed / errSecCreateChainFailed:  / The attempt to create a certificate chain failed."
```

Code Reference : https://github.com/couchbase/couchbase-lite-core/blob/master/Crypto/PublicKey%2BApple.mm#L809-L813

This issue was found while testing CBL-C Replicator on Mac with a Capella endpoint. Even though there is an error logged but a root CA cert of the Capella endpoint was still found by the SecTrustEvaluateWithError() for some reason. To avoid unexpected issue when intermediate certs are required for validation, we should include all of the certs received from the remote server for validation.

**Fix:**

This commit is constructing and passing the cert chain (in PEM format) to the root_cert_locator(). The passed cert chain, will eventually be passed to the findSigningRootCert() that Apple platform can use when constructing an array of SecCertRef for creating a SecTrust. 

Note that there will be a corresponding fix in LiteCore to create a SecTrust with the cert chain as well.