### PR TITLE
CBL-4238 : Pass cert chain to the root_cert_locator()

### DIFF
--- a/src/mbedtls_context.cpp
+++ b/src/mbedtls_context.cpp
@@ -37,11 +37,13 @@
 #include "sockpp/mbedtls_context.h"
 #include "sockpp/connector.h"
 #include "sockpp/exception.h"
+#include <mbedtls/base64.h>
 #include <mbedtls/ctr_drbg.h>
 #include <mbedtls/debug.h>
 #include <mbedtls/entropy.h>
 #include <mbedtls/error.h>
 #include <mbedtls/net_sockets.h>
+#include <mbedtls/pem.h>
 #include <mbedtls/ssl.h>
 #include <mutex>
 #include <chrono>
@@ -585,7 +587,38 @@ namespace sockpp {
     {
         if (!root_cert_locator_)
             return -1;
-        string certData((const char*)child->raw.p, child->raw.len);
+        
+        // Construct the cert chain including all intermediates in PEM format:
+        string certData;
+        for (auto crt = child; crt; crt = crt->next) {
+            int ret = 0;
+            size_t olen = 10000; // initial buffer size
+            std::vector<unsigned char> buf;
+            for (int i = 0; i < 2; i++) {
+                buf.resize(olen);
+                ret = mbedtls_pem_write_buffer("-----BEGIN CERTIFICATE-----\n",
+                                               "-----END CERTIFICATE-----\n",
+                                               crt->raw.p, crt->raw.len,
+                                               buf.data(), buf.size(), &olen);
+                if (ret != MBEDTLS_ERR_BASE64_BUFFER_TOO_SMALL) {
+                    break;
+                }
+            }
+            
+            if (ret != 0) {
+                if (ret > 0) {
+                    ret = MBEDTLS_ERR_X509_CERT_UNKNOWN_FORMAT;
+                }
+                log_mbed_ret(ret, "mbedtls_pem_write_buffer");
+                return ret;
+            }
+            
+            if (olen > 0 && buf[olen-1] == '\0') {
+                olen = olen - 1; // Not include '\0'
+            }
+            certData.append((const char*)buf.data(), olen);
+        }
+        
         string rootData;
         if (!root_cert_locator_(certData, rootData))
             return -1;//TEMP


### PR DESCRIPTION
* Ported the fix from release/3.1 branch (6fde3088edd41fa549dced003ba01a41fe0697cc) which is for CBL-4237.

Background :

In LiteCore PublicKey+Apple.mm’s findSigningRootCert() for TLS CA cert validation, a SecTrust is created with only a leaf cert without its intermediate certs. As a result, when calling SecTrustEvaluateWithError() to evaluate the SecTrust (a technique to get all certs including the root CA cert used for verifying a CA signed cert), there is an error logged as follows:

```
[TLS] error: SecTrustEvaluateWithError failed: Error Domain=NSOSStatusErrorDomain Code=-25318 "errKCCreateChainFailed / errSecCreateChainFailed:  / The attempt to create a certificate chain failed."
```

Fix:

* This commit is constructing and passing the cert chain (in PEM format) to the root_cert_locator(). The passed cert chain, will eventually be passed to the findSigningRootCert() that Apple platform can use when constructing an array of SecCertRef for creating a SecTrust. Note that there will be a corresponding fix in LiteCore regarding this as well.

* Use vector<char> as a dynamic buffer with an initial buffer size of 10000 which should be big enough for most cases. When the buffer size is not big enough, resize the buffer with the min buffer size set in olen out param by the mbedtls_pem_write_buffer function and retry again.