### PR TITLE
CBL-4584 : Translate ECONNABORTED to MBEDTLS_ERR_NET_CONN_RESET

### DIFF
--- a/src/mbedtls_context.cpp
+++ b/src/mbedtls_context.cpp
@@ -415,8 +415,10 @@ namespace sockpp {
             switch (result.error) {
                 case EPIPE:
                 case ECONNRESET:
+                case ECONNABORTED:
 #ifdef _WIN32
                 case WSAECONNRESET:
+                case WSAECONNABORTED:
 #endif
                     return MBEDTLS_ERR_NET_CONN_RESET;
                 case EINTR:


### PR DESCRIPTION
* Issue : On android platform (from CBL-C), when turning off internet / wifi on the simulator or device, the error reported is `ECONNABORTED`, which should be a transient error but it is not. The `ECONNABORTED` was in turn converted to a generic MBEDTLS_ERR_NET_RECV_FAILED / MBEDTLS_ERR_NET_SEND_FAILED and then EIO later. The EIO is currently not a transient error. As a result, the replicator was stopped instead of offline.

* Made ECONNABORTED converted to MBEDTLS_ERR_NET_CONN_RESET and that will be converted to ECONNRESET which is a transient error in LiteCore.

* This fix was planed to put into 3.1.1.