### PR TITLE
Move TLS cert-verify state off the shared mbedtls_context

### DIFF
--- a/include/sockpp/mbedtls_context.h
+++ b/include/sockpp/mbedtls_context.h
@@ -55,6 +55,7 @@
 
 struct mbedtls_pk_context;
 struct mbedtls_ssl_config;
+struct mbedtls_ssl_context;
 struct mbedtls_x509_crt;
 
 namespace sockpp {
@@ -106,7 +107,33 @@ namespace sockpp {
         using Logger = std::function<void(int level, const char *filename, int line, const char *message)>;
         void set_logger(int threshold, Logger);
         
-        const std::string& get_peer_certificate() const { return received_cert_data_; }
+        /**
+         * The results of verifying one peer's certificate chain.
+         *
+         * This state belongs to a single TLS connection, so it must NOT be stored on the
+         * context: one context is routinely shared by many sockets that handshake on
+         * different threads at the same time (e.g. a listener accepting connections), and
+         * concurrent writes to a shared std::string corrupt the heap. [CBL-8759]
+         */
+        struct verify_state {
+            /// Did any cert in the chain match the context's pinned cert?
+            bool pinned_cert_matched {false};
+            /// Raw (DER) data of the peer's leaf cert, as seen during verification.
+            /// Needed because mbedTLS discards the peer cert when a handshake fails.
+            std::string peer_cert_data;
+
+            // Set by setup_verify(); callers should leave it alone.
+            mbedtls_context* context {nullptr};
+        };
+
+        /**
+         * Directs this context's certificate verification callback to record its results in
+         * `state`, for the one connection `ssl`. `state` must outlive `ssl`.
+         *
+         * Anyone who sets up their own `mbedtls_ssl_context` from `get_ssl_config()` should
+         * call this; without it the verification results have nowhere per-connection to live.
+         */
+        void setup_verify(mbedtls_ssl_context *ssl, verify_state *state);
 
         mbedtls_ssl_config* get_ssl_config() const {return ssl_config_.get();}
 
@@ -121,7 +148,7 @@ namespace sockpp {
         struct cert;
         struct key;
 
-        int verify_callback(mbedtls_x509_crt *crt, int depth, uint32_t *flags);
+        int verify_callback(verify_state &state, mbedtls_x509_crt *crt, int depth, uint32_t *flags);
         int trusted_cert_callback(void *context, mbedtls_x509_crt const *child,
                                   mbedtls_x509_crt **candidates);
         static std::unique_ptr<cert> parse_cert(const std::string &cert_data, bool partialOk);
@@ -130,8 +157,6 @@ namespace sockpp {
         RootCertLocator root_cert_locator_;
         std::unique_ptr<cert> root_certs_;
         std::unique_ptr<cert> pinned_cert_;
-        bool pinned_cert_validation_result_ {false};
-        std::string received_cert_data_;
 
         std::unique_ptr<cert> identity_cert_;
         std::unique_ptr<key> identity_key_;

--- a/src/mbedtls_context.cpp
+++ b/src/mbedtls_context.cpp
@@ -109,6 +109,9 @@ namespace sockpp {
     class mbedtls_socket : public tls_socket {
     private:
         mbedtls_context& context_;
+        // Declared before ssl_ so it outlives the SSL context that points at it.
+        // It is mine alone, not the (shared) context's. [CBL-8759]
+        mbedtls_context::verify_state verify_state_;
         mbedtls_ssl_context ssl_;
         chrono::microseconds read_timeout_ {0L};
         bool open_ = false;
@@ -151,6 +154,9 @@ namespace sockpp {
             if (check_mbed_setup(mbedtls_ssl_setup(&ssl_, context_.ssl_config_.get()),
                                "mbedtls_ssl_setup"))
                 return;
+
+            // Verification results go in my own verify_state_, not the shared context's:
+            context_.setup_verify(&ssl_, &verify_state_);
             if (!hostname.empty() && check_mbed_setup(mbedtls_ssl_set_hostname(&ssl_, hostname.c_str()),
                                                     "mbedtls_ssl_set_hostname"))
                 return;
@@ -255,7 +261,7 @@ namespace sockpp {
             if (!cert) {
                 // This should only happen in a failed handshake scenario, or if there
                 // was no cert to begin with
-                return context_.get_peer_certificate();
+                return verify_state_.peer_cert_data;
             }
             
             return string((const char*)cert->raw.p, cert->raw.len);
@@ -577,11 +583,28 @@ namespace sockpp {
         if (roots)
             mbedtls_ssl_conf_ca_chain(ssl_config_.get(), roots, nullptr);
 
-        // Install a custom verification callback that will call my verify_callback():
+        // Install a custom verification callback that will call my verify_callback().
+        //
+        // This config-wide callback is only a fallback, for SSL contexts set up straight from
+        // get_ssl_config() whose owner never called setup_verify(); mbedtls_socket and anyone
+        // else who calls setup_verify() gets a per-connection callback that takes precedence.
+        // The fallback's state has to live *somewhere*, and it cannot be `this` -- one context
+        // is shared by every connection, so that is exactly the data race that made rejected
+        // peers abort the process [CBL-8759]. A thread-local works instead: mbedTLS verifies a
+        // whole cert chain synchronously inside one mbedtls_ssl_handshake() call, so a chain
+        // always sees consistent state and two connections can never interleave.
         mbedtls_ssl_conf_verify(
                         ssl_config_.get(),
                         [](void *ctx, mbedtls_x509_crt *crt, int depth, uint32_t *flags) {
-                            return ((mbedtls_context*)ctx)->verify_callback(crt,depth,flags);
+                            static thread_local verify_state sState;
+                            static thread_local int sPrevDepth = -1;
+                            // mbedTLS walks a chain from root to leaf, so a depth that isn't
+                            // lower than the last one means a new chain has begun:
+                            if (depth >= sPrevDepth)
+                                sState = {};
+                            sPrevDepth = depth;
+                            return ((mbedtls_context*)ctx)->verify_callback(sState, crt,
+                                                                           depth, flags);
                         },
                         this);
     }
@@ -717,6 +740,18 @@ namespace sockpp {
     }
 
 
+    void mbedtls_context::setup_verify(mbedtls_ssl_context *ssl, verify_state *state) {
+        state->context = this;
+        // A connection-specific callback; takes precedence over mbedtls_ssl_conf_verify()'s.
+        mbedtls_ssl_set_verify(ssl,
+                        [](void *ctx, mbedtls_x509_crt *crt, int depth, uint32_t *flags) {
+                            auto state = (verify_state*)ctx;
+                            return state->context->verify_callback(*state, crt, depth, flags);
+                        },
+                        state);
+    }
+
+
     // Callback from mbedTLS cert validation (see above)
     //
     // When a pinned cert is specified, the verify_callback will compare the pinned cert with
@@ -724,31 +759,35 @@ namespace sockpp {
     // presented cert (leaf cert) is trusted.
     //
     // The verify_callback is called for each cert in the chain from root to leaf cert. The
-    // pinned_cert_validation_result_ will store the previous comparison result. If the
+    // state's pinned_cert_matched will store the previous comparison result. If the
     // comparison result is already matched, the comparison will be skipped.
     //
     // The last callback for the leaf cert is where the comparison or verification is set
     // to the status flags. The flags of the parent certs are ignored (clear).
     //
-    int mbedtls_context::verify_callback(mbedtls_x509_crt *crt, int depth, uint32_t *flags) {
-        if (pinned_cert_ && !pinned_cert_validation_result_) {
-            pinned_cert_validation_result_ = (crt->raw.len == pinned_cert_->raw.len &&
-                                              0 == memcmp(crt->raw.p, pinned_cert_->raw.p, crt->raw.len));
+    // `state` accumulates results across the chain and so must belong to this one connection;
+    // see the comment on mbedtls_ssl_conf_verify() in the constructor. Nothing here may touch
+    // mutable state on `this`, which is shared by every connection using this context.
+    //
+    int mbedtls_context::verify_callback(verify_state &state,
+                                        mbedtls_x509_crt *crt, int depth, uint32_t *flags) {
+        if (pinned_cert_ && !state.pinned_cert_matched) {
+            state.pinned_cert_matched = (crt->raw.len == pinned_cert_->raw.len &&
+                                         0 == memcmp(crt->raw.p, pinned_cert_->raw.p, crt->raw.len));
         }
-		
-		auto &callback = get_auth_callback();
-        
+
+        auto &callback = get_auth_callback();
+
         if (depth == 0) { // leaf cert
-            received_cert_data_ = string((const char *)crt->raw.p, crt->raw.len);
-            
+            state.peer_cert_data.assign((const char *)crt->raw.p, crt->raw.len);
+
             int status = -1;
             if (pinned_cert_) {
-                status = pinned_cert_validation_result_;
+                status = state.pinned_cert_matched;
             } else if (callback) {
-                string certData((const char*)crt->raw.p, crt->raw.len);
-                status = callback(certData);
+                status = callback(state.peer_cert_data);
             }
-            
+
             if (status > 0) {
                 *flags &= ~(MBEDTLS_X509_BADCERT_NOT_TRUSTED | MBEDTLS_X509_BADCERT_CN_MISMATCH);
             } else if (status == 0) {


### PR DESCRIPTION
## Problem

`mbedtls_context::verify_callback()` recorded its results in two members of the context itself:
`received_cert_data_` (a `std::string`) and `pinned_cert_validation_result_`.

But a context is shared by every connection made through it — a listener creates one and uses it
for all the connections it accepts — and each connection runs its handshake on its own thread.
Two peers handshaking at the same moment therefore both move-assigned that same `std::string`,
freeing the same buffer twice:

```
Scudo ERROR: invalid chunk state when deallocating address 0x2000075ea087f10
F libc: Fatal signal 6 (SIGABRT) ... tid 5638 (Thread-14050)
```

Reported against a CBL 3.4 multipeer listener in a mesh with CBL 4.1 peers. The 4.1 peers
negotiate a subprotocol 3.4 doesn't support, so they're rejected with a 403 and retry every ~5s —
but that check is at the HTTP layer, *after* a completed TLS handshake, so the retry loop just
manufactures a steady stream of concurrent handshakes until two land in the same window.

## Fix

Move that state into a new `mbedtls_context::verify_state` belonging to a single connection.
`mbedtls_socket` owns one and binds it with the new `setup_verify()`, which installs a
connection-specific callback via `mbedtls_ssl_set_verify()` — mbedTLS gives that precedence over
the one from `mbedtls_ssl_conf_verify()`. `peer_certificate()` reads the socket's own copy
instead of the context's.

The config-wide callback stays, for SSL contexts set up straight from `get_ssl_config()` whose
owner never calls `setup_verify()`, but its state is now a thread-local instead of the context.
mbedTLS verifies a whole chain synchronously inside one `mbedtls_ssl_handshake()` call, so a
chain still sees consistent state and two connections cannot interleave. Removing that callback
outright would have silently disabled cert authentication for those users, which is worse than
the bug being fixed here.

`mbedtls_context::get_peer_certificate()` is removed; it had no callers outside sockpp.

## Also fixes

`pinned_cert_validation_result_` was only ever set, never cleared. Once any connection through a
context matched the pinned cert, every later connection on that context skipped the comparison
and was trusted without being checked. Per-connection state fixes this as a side effect.

## Testing

Compile-verified only (MSVC 14.51, `/std:c++20 /W3`, clean). **Not yet run** — the regression
tests live in core and are not part of this PR.

Follow-ups, in order:
1. This PR.
2. couchbase-lite-core: submodule pointer bump + `Networking/tests/TLSContextTest.cc`, which
   covers both the concurrent-handshake crash and the pinned-cert leak. The pinned-cert test is
   deterministic and fails without this change; the concurrency test needs `LITECORE_SANITIZE`.
3. couchbase-lite-core-EE: `P2P/TLSCodec.cc` calls `setup_verify()` so the BTLE path uses real
   per-connection state rather than the thread-local fallback. Must land after this.

Also needs porting to `release/3.4` and `release/4.1`, which carry the identical sockpp commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)